### PR TITLE
Change lhttpc uri and commit

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,8 +33,8 @@
     }
   , { lhttpc
     , ".*"
-    , { git, "git://github.com/waisbrot/lhttpc.git"
-      , "824a89316d59353181990f5a461157751ca67907"
+    , { git, "git://github.com/esl/lhttpc.git"
+      , "6530ef818bf904bf4ef615f384d2fc7bae44a6dc"
       }
     }
   , { neotoma


### PR DESCRIPTION
Now it's esl/lhttpc commit 6530ef818bf904bf4ef615f384d2fc7bae44a6dc
The prev repo and commit doesn't work as the branch containing
commit 824a89316d59353181990f5a461157751ca67907 was removed

We need this change to be able to fully test esl/MongooseIM