### PR TITLE
lhttpc -> hackney. fixes #17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ script:
   - "[[ ${TRAVIS_OTP_RELEASE} == 18.1 ]] && make elvis || true"
   - make .rebar/DEV_MODE
   - make
-  - make test
+  - make .rebar/DEV_MODE deps eunit
+  - "[[ ${TRAVIS_OTP_RELEASE} == 18.1 ]] && make dialyzer || true"

--- a/rebar.config
+++ b/rebar.config
@@ -32,10 +32,10 @@
       , "1a1c913ac80bb45d3de5fbd74d21e96c45e9e844"
       }
     }
-  , { lhttpc
+  , { hackney
     , ".*"
-    , { git, "git://github.com/esl/lhttpc.git"
-      , "6530ef818bf904bf4ef615f384d2fc7bae44a6dc"
+    , { git, "git://github.com/benoitc/hackney.git"
+      , {tag, "1.4.4"}
       }
     }
   , { neotoma
@@ -71,6 +71,10 @@
                     , asn1
                     , public_key
                     , ssl
-                    , lhttpc
+                    , ssl_verify_hostname
+                    , idna
+                    , mimerl
+                    , certifi
+                    , hackney
                     , tdiff
                     ]}.

--- a/src/katt.app.src
+++ b/src/katt.app.src
@@ -15,7 +15,7 @@
                                      , asn1
                                      , public_key
                                      , ssl
-                                     , lhttpc
+                                     , hackney
                                      , tdiff
                                      ]}
                     ]}.

--- a/src/katt_callbacks.erl
+++ b/src/katt_callbacks.erl
@@ -250,7 +250,7 @@ http_request( #katt_request{ method = Method
   Hdrs1 = proplists:delete("x-katt-sleep", Hdrs0),
   Hdrs = proplists:delete("x-katt-timeout", Hdrs1),
   timer:sleep(Sleep),
-  lhttpc:request(Url, Method, Hdrs, Body, Timeout, []).
+  katt_util:external_http_request(Url, Method, Hdrs, Body, Timeout, []).
 
 validate_status( #katt_response{status=E}
                , #katt_response{status=A}

--- a/src/katt_cli.erl
+++ b/src/katt_cli.erl
@@ -84,7 +84,10 @@ katt_run(ScenarioFilename, Params0) ->
   ok = ensure_started(asn1),
   ok = ensure_started(public_key),
   ok = ensure_started(ssl),
-  ok = ensure_started(lhttpc),
+  ok = ensure_started(idna),
+  ok = ensure_started(mimerl),
+  ok = ensure_started(certifi),
+  ok = ensure_started(hackney),
   ok = ensure_started(tdiff),
   ok = ensure_started(katt),
   katt:run( ScenarioFilename

--- a/test/katt_run_tests.erl
+++ b/test/katt_run_tests.erl
@@ -34,15 +34,15 @@ katt_test_() ->
                  , file
                  , fun mock_katt_blueprint_parse_file/1
                  ),
-      meck:new(lhttpc, [passthrough]),
-      meck:expect( lhttpc
-                 , request
+      meck:new(katt_callbacks, [passthrough]),
+      meck:expect( katt_util
+                 , external_http_request
                  , fun mock_lhttpc_request/6
                  )
     end
   , fun(_) ->
       meck:unload(katt_blueprint_parse),
-      meck:unload(lhttpc)
+      meck:unload(katt_callbacks)
     end
   , [ katt_run_basic()
     , katt_run_with_params()
@@ -222,7 +222,7 @@ mock_lhttpc_request( "http://127.0.0.1/step5"
                    , _Timeout
                    , _Options
                    ) ->
-  {ok, {{404, "Not found"}, [{"Content-Type", "text/html"}], <<>>}};
+  {ok, {{404, []}, [{"Content-Type", "text/html"}], <<>>}};
 
 %% Mock response for test-params:
 mock_lhttpc_request( "http://example.com/test-params"

--- a/test/katt_run_unexpected_tests.erl
+++ b/test/katt_run_unexpected_tests.erl
@@ -34,15 +34,15 @@ katt_test_() ->
                  , file
                  , fun mock_katt_blueprint_parse_file/1
                  ),
-      meck:new(lhttpc, [passthrough]),
-      meck:expect( lhttpc
-                 , request
+      meck:new(katt_callbacks, [passthrough]),
+      meck:expect( katt_util
+                 , external_http_request
                  , fun mock_lhttpc_request/6
                  )
     end
   , fun(_) ->
       meck:unload(katt_blueprint_parse),
-      meck:unload(lhttpc)
+      meck:unload(katt_callbacks)
     end
   , [ katt_run_with_unexpected_disallow()
     , katt_run_with_expected_but_undefined()

--- a/test/katt_run_validate_type_set_tests.erl
+++ b/test/katt_run_validate_type_set_tests.erl
@@ -33,15 +33,15 @@ katt_test_() ->
                  , file
                  , fun mock_katt_blueprint_parse_file/1
                  ),
-      meck:new(lhttpc, [passthrough]),
-      meck:expect( lhttpc
-                 , request
+      meck:new(katt_callbacks, [passthrough]),
+      meck:expect( katt_util
+                 , external_http_request
                  , fun mock_lhttpc_request/6
                  )
     end
   , fun(_) ->
       meck:unload(katt_blueprint_parse),
-      meck:unload(lhttpc)
+      meck:unload(katt_callbacks)
     end
   , [ katt_run_with_set_comparison_strict()
     , katt_run_with_set_comparison_strict_fails()


### PR DESCRIPTION
Hackney WARNING: **Supported versions of Erlang are R16B03-1, 17.3.4 and above. It is reported to work with R14B04 and R15B03-1.**