### PR TITLE
Allow to compile katt as a dependency

### DIFF
--- a/priv/compile-parser
+++ b/priv/compile-parser
@@ -4,6 +4,10 @@
 %% grammar file.
 
 main(_) ->
-    Neotoma = filename:dirname(escript:script_name()) ++ "/../deps/neotoma/ebin",
-    code:add_pathz(filename:absname(Neotoma)),
+    %% Katt is the main project
+    Neotoma1 = filename:dirname(escript:script_name()) ++ "/../deps/neotoma/ebin",
+    %% Katt is a dependency
+    Neotoma2 = filename:dirname(escript:script_name()) ++ "/../../neotoma/ebin",
+    code:add_pathz(filename:absname(Neotoma1)),
+    code:add_pathz(filename:absname(Neotoma2)),
     neotoma:file("priv/katt_blueprint.peg", [{output, "src/"}]).


### PR DESCRIPTION
Katt is not compiled properly when used as a dependency.
It's easy to fix by setting two possible paths.
See a related bug in MongooseIM for more information https://github.com/esl/MongooseIM/issues/644