### PR TITLE
add textual diff for strings. fix #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ bin/katt --json hostname=httpbin.org my_name=Joe your_name=Mike -- ./doc/example
     * `request` to be called with `request`, `params`, `callbacks`
     * `validate` to be called with `expected`, `actual`, `params`, `callbacks`
     * `progress` to be called with `transaction_result`
+    * `text_diff` to be called with `text`, `text`
 
 A request can also be configured via HTTP request headers:
 

--- a/rebar.config
+++ b/rebar.config
@@ -44,6 +44,12 @@
       , {tag, "1.6.1"}
       }
     }
+  , { tdiff
+    , ".*"
+    , { git, "git://github.com/tomas-abrahamsson/tdiff.git"
+      , "bbb54ce20df388f2c7d01e8df30ef471ca98d0fb"
+      }
+    }
   ]}.
 { dev_only_deps
 , [ { meck
@@ -66,4 +72,5 @@
                     , public_key
                     , ssl
                     , lhttpc
+                    , tdiff
                     ]}.

--- a/src/katt.app.src
+++ b/src/katt.app.src
@@ -16,5 +16,6 @@
                                      , public_key
                                      , ssl
                                      , lhttpc
+                                     , tdiff
                                      ]}
                     ]}.

--- a/src/katt.erl
+++ b/src/katt.erl
@@ -117,6 +117,7 @@ make_callbacks(Callbacks) ->
                             , {request, ?DEFAULT_REQUEST_FUN}
                             , {validate, ?DEFAULT_VALIDATE_FUN}
                             , {progress, ?DEFAULT_PROGRESS_FUN}
+                            , {text_diff, ?DEFAULT_TEXT_DIFF_FUN}
                             ], Callbacks).
 
 %%%_* Internal =================================================================

--- a/src/katt.hrl
+++ b/src/katt.hrl
@@ -44,6 +44,7 @@
 -define(DEFAULT_REQUEST_FUN,        fun katt_callbacks:request/3).
 -define(DEFAULT_VALIDATE_FUN,       fun katt_callbacks:validate/4).
 -define(DEFAULT_PROGRESS_FUN,       fun katt_callbacks:progress/2).
+-define(DEFAULT_TEXT_DIFF_FUN,      fun katt_callbacks:text_diff/2).
 
 -type scenario_filename()   :: nonempty_string().
 -type params()              :: [{param_name(), param()}].

--- a/src/katt_callbacks.erl
+++ b/src/katt_callbacks.erl
@@ -32,6 +32,7 @@
         , validate/4
         , validate_type/6
         , progress/2
+        , text_diff/2
         ]).
 
 %%%_* Includes =================================================================
@@ -200,6 +201,14 @@ validate(#katt_response{}, Actual, _Params, _Callbacks)   -> {fail, Actual}.
 progress(_Step, _Detail) ->
   ok.
 
+%% @doc Perform a text diff
+%% @end
+-spec text_diff( list()
+               , list()
+               ) -> proplists:proplist().
+text_diff(A, B) ->
+  [{text_diff, tdiff:diff(A, B)}].
+
 %%%_* Internal =================================================================
 
 get_params_and_failures(Result) when not is_list(Result) ->
@@ -255,7 +264,7 @@ validate_status( #katt_response{status=E}
 %% The header name (not the value) is compared case-insensitive
 validate_headers( #katt_response{headers=E0}
                 , #katt_response{headers=A0}
-                , _Callbacks
+                , Callbacks
                 ) ->
   LowerE = [{katt_util:to_lower(K), V} || {K, V} <- E0],
   LowerA = [{katt_util:to_lower(K), V} || {K, V} <- A0],
@@ -286,7 +295,7 @@ validate_headers( #katt_response{headers=E0}
                            ),
   E = {struct, ConcatenatedE},
   A = {struct, ConcatenatedA},
-  katt_util:validate("/headers", E, A, ?MATCH_ANY, []).
+  katt_util:validate("/headers", E, A, ?MATCH_ANY, Callbacks).
 
 concatenate_header(Header, Headers) ->
   Values = proplists:get_all_values(Header, Headers),

--- a/src/katt_cli.erl
+++ b/src/katt_cli.erl
@@ -85,6 +85,7 @@ katt_run(ScenarioFilename, Params0) ->
   ok = ensure_started(public_key),
   ok = ensure_started(ssl),
   ok = ensure_started(lhttpc),
+  ok = ensure_started(tdiff),
   ok = ensure_started(katt),
   katt:run( ScenarioFilename
           , Params


### PR DESCRIPTION
**NOTE**: a backwards-incompatible change, a failure now has expected, actual value, but also "details" (in this case, a text_diff detail)

An example of the new JSON output

```json
      "errors": [
        {
          "reason": "not_equal",
          "key": "/body/args/whoarewe",
          "expected": "asdMikeJoe",
          "actual": "Mike_and_Joe",
          "text_diff": [
            {
              "del": "asd"
            },
            {
              "eq": "Mike"
            },
            {
              "ins": "_and_"
            },
            {
              "eq": "Joe"
            }
          ]
        }
      ]
```