### PR TITLE
Http client agnosticism

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,12 +32,6 @@
       , {tag, "2.8.0"}
       }
     }
-  , { hackney
-    , ".*"
-    , { git, "git://github.com/benoitc/hackney.git"
-      , {tag, "1.4.9"}
-      }
-    }
   , { neotoma
     , ".*"
     , { git, "git://github.com/seancribbs/neotoma.git"
@@ -59,6 +53,13 @@
       }
     }
   ]}.
+{http_client_library,
+ { hackney
+ , ".*"
+ , { git, "git://github.com/benoitc/hackney.git"
+   , {tag, "1.4.9"}
+   }
+ }}.
 {pre_hooks, [{compile, "./priv/compile-parser"}]}.
 {escript_name, "bin/katt"}.
 {escript_emu_args, "%%! -noinput\n"}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -44,14 +44,30 @@ Deps = {deps, DevOnlyDeps},
 ConfigPath = filename:dirname(SCRIPT),
 DevMarker = filename:join([ConfigPath, ".rebar", "DEV_MODE"]),
 _ = filelib:ensure_dir(DevMarker),
-case filelib:is_file(DevMarker) of
-    true ->
-        lists:foldl(fun(I, C) -> MergeConfig(I, C) end,
-                    CONFIG, [Deps, ErlOpts]);
+
+CONFIG1 = case filelib:is_file(DevMarker) of
+              true ->
+                  lists:foldl(fun(I, C) -> MergeConfig(I, C) end,
+                              CONFIG, [Deps, ErlOpts]);
+              false ->
+                  %% If the ./.rebar/DEV_MODE marker is not present, this script
+                  %% simply returns the config specified in rebar.config. This
+                  %% will be the behavior when the project is built as a
+                  %% dependency of another project.
+                  CONFIG
+          end,
+
+NoClientMarker = filename:join([ConfigPath, ".rebar", "NO_HTTP_CLIENT"]),
+case filelib:is_file(NoClientMarker) of
     false ->
-        %% If the ./.rebar/DEV_MODE marker is not present, this script simply
-        %% returns the config specified in rebar.config. This will be
-        %% the behavior when the project is built as a dependency of
-        %% another project.
-        CONFIG
-end.
+        %% If the ./.rebar/NO_HTTP_CLIENT marker is not present, this script
+        %% adds hackney as the dependency.
+        {_, {Name, _, _} = HttpClient} = lists:keyfind(http_client_library,
+                                                       1,
+                                                       CONFIG1),
+        lists:foldl(fun(I, C) -> MergeConfig(I, C) end,
+                    CONFIG1,
+                    [{deps, [HttpClient]}, {escript_incl_apps, [Name]}]);
+    true ->
+        CONFIG1
+         end.

--- a/src/katt.app.src
+++ b/src/katt.app.src
@@ -14,7 +14,6 @@
                                      , asn1
                                      , public_key
                                      , ssl
-                                     , hackney
                                      , tdiff
                                      ]}
                     ]}.

--- a/src/katt.erl
+++ b/src/katt.erl
@@ -85,7 +85,7 @@ run(Scenario, ScenarioParams, ScenarioCallbacks, ScenarioOptions) ->
                                    , Callbacks
                                    ),
   HttpClient = proplists:get_value(http_client, Options),
-  ok = HttpClient:init([]),
+  ok = katt_http_client:init(HttpClient, []),
   spawn_link(?MODULE, run, [self(), Scenario, Params, Callbacks, Options]),
   run_loop(ScenarioTimeout, ProgressFun).
 

--- a/src/katt.hrl
+++ b/src/katt.hrl
@@ -41,10 +41,12 @@
 -define(DEFAULT_EXT_FUN,            fun katt_callbacks:ext/1).
 -define(DEFAULT_RECALL_FUN,         fun katt_callbacks:recall/4).
 -define(DEFAULT_PARSE_FUN,          fun katt_callbacks:parse/4).
--define(DEFAULT_REQUEST_FUN,        fun katt_callbacks:request/3).
+-define(DEFAULT_REQUEST_FUN,        fun katt_callbacks:request/4).
 -define(DEFAULT_VALIDATE_FUN,       fun katt_callbacks:validate/4).
 -define(DEFAULT_PROGRESS_FUN,       fun katt_callbacks:progress/2).
 -define(DEFAULT_TEXT_DIFF_FUN,      fun katt_callbacks:text_diff/2).
+
+-define(DEFAULT_HTTP_CLIENT_MOD,    katt_http_client_hackney).
 
 -type scenario_filename()   :: nonempty_string().
 -type params()              :: [{param_name(), param()}].
@@ -56,6 +58,7 @@
                              | string()
                              | binary().
 -type callbacks()           :: [{atom(), function()}].
+-type options()             :: [{atom(), term()}].
 
 -type run_result()          :: run_error()
                              | scenario_result().

--- a/src/katt_callbacks.erl
+++ b/src/katt_callbacks.erl
@@ -252,8 +252,8 @@ http_request( #katt_request{ method = Method
   Hdrs1 = proplists:delete("x-katt-sleep", Hdrs0),
   Hdrs = proplists:delete("x-katt-timeout", Hdrs1),
   timer:sleep(Sleep),
-  Client = proplists:get_value(http_client, Options),
-  Client:request(Method, Url, Hdrs, Body, Timeout).
+  HttpClient = proplists:get_value(http_client, Options),
+  katt_http_client:request(HttpClient, Method, Url, Hdrs, Body, Timeout).
 
 validate_status( #katt_response{status=E}
                , #katt_response{status=A}

--- a/src/katt_cli.erl
+++ b/src/katt_cli.erl
@@ -97,17 +97,9 @@ katt_run(ScenarioFilename, Params) ->
   %% Don't use application:ensure_all_started(katt)
   %% nor application:ensure_started(_)
   %% in order to maintain compatibility with R16B01 and lower
-  ok = ensure_started(jsx),
-  ok = ensure_started(crypto),
-  ok = ensure_started(asn1),
-  ok = ensure_started(public_key),
-  ok = ensure_started(ssl),
-  ok = ensure_started(idna),
-  ok = ensure_started(mimerl),
-  ok = ensure_started(certifi),
-  ok = ensure_started(hackney),
-  ok = ensure_started(tdiff),
-  ok = ensure_started(katt),
+  ok = katt_util:ensure_applications_started([ jsx
+                                             , tdiff
+                                             , katt]),
   katt:run( ScenarioFilename
           , Params
           , [{ progress
@@ -181,12 +173,4 @@ try_to_convert_to([boolean|Rest], Value0) ->
       false;
     _ ->
       try_to_convert_to(Rest, Value0)
-  end.
-
-ensure_started(App) ->
-  case application:start(App) of
-    ok ->
-      ok;
-    {error, {already_started, App}} ->
-      ok
   end.

--- a/src/katt_http_client.erl
+++ b/src/katt_http_client.erl
@@ -1,0 +1,65 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Copyright 2012- Klarna AB
+%%% Copyright 2014- AUTHORS
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+%%% @copyright 2012- Klarna AB, AUTHORS
+%%%
+%%% @doc Klarna API Testing Tool Utils
+%%% @end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%_* Module declaration =======================================================
+%% @private
+-module(katt_http_client).
+
+%%%_* Exports ==================================================================
+
+-export([init/2,
+         request/6]).
+
+%%%_* Types ====================================================================
+
+-type method()  :: string()
+                 | atom().
+-type url()     :: string().
+-type headers() :: [[{string() | atom(), string()}]].
+-type body()    :: iolist().
+-type result()  :: {ok, {{pos_integer(), string()}, headers(), binary()}}
+                 | {error, atom()}.
+
+
+%%%_* Callbacks ================================================================
+
+-callback init(Args       :: [term()]) -> ok.
+-callback request(Method  :: method(),
+                  URL     :: url(),
+                  Headers :: headers(),
+                  Body    :: body(),
+                  Timeout :: timeout()) -> result().
+
+%%%_* API ======================================================================
+
+-spec init(CBModule :: module(), Args :: [term()]) -> ok.
+init(CBModule, Args) ->
+  CBModule:init(Args).
+
+-spec request(CBModule :: module(),
+              Method   :: method(),
+              URL      :: url(),
+              Headers  :: headers(),
+              Body     :: body(),
+              Timeout  :: timeout()) -> result().
+request(CBModule, Method, URL, Headers, Body, Timeout) ->
+  CBModule:request(Method, URL, Headers, Body, Timeout).

--- a/src/katt_http_client_hackney.erl
+++ b/src/katt_http_client_hackney.erl
@@ -1,0 +1,73 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Copyright 2012- Klarna AB
+%%% Copyright 2014- AUTHORS
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+%%% @copyright 2012- Klarna AB, AUTHORS
+%%%
+%%% @doc Klarna API Testing Tool Utils
+%%% @end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%_* Module declaration =======================================================
+%% @private
+-module(katt_http_client_hackney).
+
+%%%_* Exports ==================================================================
+%% API
+-export([ init/1
+        , request/5
+        ]).
+
+%%%_* Includes =================================================================
+
+%%%_* API ======================================================================
+
+init(_) ->
+    katt_util:ensure_applications_started([ kernel
+                                          , stdlib
+                                          , crypto
+                                          , asn1
+                                          , public_key
+                                          , ssl
+                                          , idna
+                                          , mimerl
+                                          , certifi]).
+
+request(Method, Url, Hdrs, Body, Timeout) ->
+  BUrl = list_to_binary(Url),
+  BHdrs = lists:map( fun({Name, Value})->
+                         {list_to_binary(Name), list_to_binary(Value)}
+                     end
+                   , Hdrs
+                   ),
+  Options = [{recv_timeout, Timeout}],
+  case hackney:request(Method, BUrl, BHdrs, Body, Options) of
+    {ok, Status, BResHdrs, Client} ->
+      %% lhttpc was the predecesor of hackney
+      %% and we're maintaining a backwards compatible return value
+      {ok, ResBody} = hackney:body(Client),
+      ResHdrs0 = lists:map( fun({Name, Value})->
+                                {binary_to_list(Name), binary_to_list(Value)}
+                            end
+                          , BResHdrs
+                          ),
+      ResHdrs = lists:reverse(ResHdrs0),
+      {ok, {{Status, ""}, ResHdrs, ResBody}};
+    Error ->
+      Error
+  end.
+
+%%%_* Internal =================================================================
+

--- a/test/katt_run_tests.erl
+++ b/test/katt_run_tests.erl
@@ -35,9 +35,9 @@ katt_test_() ->
                  , fun mock_katt_blueprint_parse_file/1
                  ),
       meck:new(katt_callbacks, [passthrough]),
-      meck:expect( katt_util
-                 , external_http_request
-                 , fun mock_lhttpc_request/6
+      meck:expect( katt_http_client_hackney
+                 , request
+                 , fun mock_hackney_request/5
                  )
     end
   , fun(_) ->
@@ -151,12 +151,11 @@ katt_run_with_struct() ->
 
 %% Mock response for Step 2:
 %% (default hostname is 127.0.0.1, default port is 80, default protocol is http)
-mock_lhttpc_request( "http://127.0.0.1/step1" = _Url
-                   , "POST" = _Method
+mock_hackney_request( "POST" = _Method
+                   , "http://127.0.0.1/step1" = _Url
                    , _Headers
                    , _Body
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, { {201, []}
        , [ {"Location", "http://127.0.0.1/step2"}
@@ -168,12 +167,11 @@ mock_lhttpc_request( "http://127.0.0.1/step1" = _Url
          ]
        , <<>>}};
 %% Mock response for Step 2:
-mock_lhttpc_request( "http://127.0.0.1/step2"
-                   , "GET"
+mock_hackney_request( "GET"
+                   , "http://127.0.0.1/step2"
                    , [{"Accept", "application/json"}]
                    , <<>>
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"Content-Type", "application/json"}], <<"{
     \"required_fields\": [
@@ -188,12 +186,11 @@ mock_lhttpc_request( "http://127.0.0.1/step2"
 
 "/utf8>>}};
 %% Mock response for Step 3:
-mock_lhttpc_request( "http://127.0.0.1/step2/step3"
-                   , "POST"
+mock_hackney_request( "POST"
+                   , "http://127.0.0.1/step2/step3"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"Content-Type", "application/json"}], <<"{
     \"required_fields\": [
@@ -203,34 +200,31 @@ mock_lhttpc_request( "http://127.0.0.1/step2/step3"
 }
 "/utf8>>}};
 %% Mock response for Step 4:
-mock_lhttpc_request( "http://127.0.0.1/step2/step4"
-                   , "POST"
+mock_hackney_request( "POST"
+                   , "http://127.0.0.1/step2/step4"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{402, []}, [{"Content-Type", "application/json"}], <<"{
     \"error\": \"payment required\"
 }
 "/utf8>>}};
 %% Mock response for Step 5:
-mock_lhttpc_request( "http://127.0.0.1/step5"
-                   , "HEAD"
+mock_hackney_request( "HEAD"
+                   , "http://127.0.0.1/step5"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{404, []}, [{"Content-Type", "text/html"}], <<>>}};
 
 %% Mock response for test-params:
-mock_lhttpc_request( "http://example.com/test-params"
-                   , "POST"
+mock_hackney_request( "POST"
+                   , "http://example.com/test-params"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"Content-Type", "application/vnd.katt.test-v1+json"}], <<"{
     \"protocol\": \"http:\",
@@ -248,14 +242,13 @@ mock_lhttpc_request( "http://example.com/test-params"
 "/utf8>>}};
 
 %% Mock response for api mismatch test:
-mock_lhttpc_request( "http://127.0.0.1/api-mismatch"
-                   , "POST"
+mock_hackney_request( "POST"
+                   , "http://127.0.0.1/api-mismatch"
                    , [ {"Accept", "application/json"}
                      , {"Content-Type", "application/json"}
                      ]
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{401, []}, [{"Content-Type", "application/json"}], <<"{
     \"error\": \"unauthorized\"
@@ -263,12 +256,11 @@ mock_lhttpc_request( "http://127.0.0.1/api-mismatch"
 "/utf8>>}};
 
 %% Mock response for store (and case-insensitive http headers) test:
-mock_lhttpc_request( "http://127.0.0.1/store"
-                   , "GET"
+mock_hackney_request( "GET"
+                   , "http://127.0.0.1/store"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"content-type", "application/json"},
                     {"set-cookie", "mycookie=param1; path=param2;"},
@@ -280,12 +272,11 @@ mock_lhttpc_request( "http://127.0.0.1/store"
 "/utf8>>}};
 
 %% Mock response for struct test:
-mock_lhttpc_request( "http://127.0.0.1/struct"
-                   , "GET"
+mock_hackney_request( "GET"
+                   , "http://127.0.0.1/struct"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"content-type", "application/json"}], <<"{
     \"array\": [],

--- a/test/katt_run_unexpected_tests.erl
+++ b/test/katt_run_unexpected_tests.erl
@@ -35,9 +35,9 @@ katt_test_() ->
                  , fun mock_katt_blueprint_parse_file/1
                  ),
       meck:new(katt_callbacks, [passthrough]),
-      meck:expect( katt_util
-                 , external_http_request
-                 , fun mock_lhttpc_request/6
+      meck:expect( katt_http_client_hackney
+                 , request
+                 , fun mock_hackney_request/5
                  )
     end
   , fun(_) ->
@@ -101,12 +101,11 @@ katt_run_with_unexpected_and_undefined() ->
 %%% Helpers
 
 %% Mock response for unexpected disallow test:
-mock_lhttpc_request( "http://127.0.0.1/unexpected-disallow"
-                   , "GET"
+mock_hackney_request( "GET"
+                   , "http://127.0.0.1/unexpected-disallow"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"Content-Type", "application/json"}], <<"{
     \"ok\": true,
@@ -119,24 +118,22 @@ mock_lhttpc_request( "http://127.0.0.1/unexpected-disallow"
 "/utf8>>}};
 
 %% Mock response for expected but undefined test:
-mock_lhttpc_request( "http://127.0.0.1/expected-but-undefined"
-                   , "GET"
+mock_hackney_request( "GET"
+                   , "http://127.0.0.1/expected-but-undefined"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"Content-Type", "application/json"}], <<"{
 }
 "/utf8>>}};
 
 %% Mock response for unexpected and undefined test:
-mock_lhttpc_request( "http://127.0.0.1/unexpected-and-undefined"
-                   , "GET"
+mock_hackney_request( "GET"
+                   , "http://127.0.0.1/unexpected-and-undefined"
                    , _
                    , _
                    , _Timeout
-                   , _Options
                    ) ->
   {ok, {{200, []}, [{"Content-Type", "application/json"}], <<"{
 }

--- a/test/katt_run_validate_type_set_tests.erl
+++ b/test/katt_run_validate_type_set_tests.erl
@@ -34,9 +34,9 @@ katt_test_() ->
                  , fun mock_katt_blueprint_parse_file/1
                  ),
       meck:new(katt_callbacks, [passthrough]),
-      meck:expect( katt_util
-                 , external_http_request
-                 , fun mock_lhttpc_request/6
+      meck:expect( katt_http_client_hackney
+                 , request
+                 , fun mock_hackney_request/5
                  )
     end
   , fun(_) ->
@@ -111,12 +111,11 @@ katt_run_with_set_comparison_unlimited_fails() ->
 
 %% Mock response for set_comparison test:
 %% (match a finite set of values)
-mock_lhttpc_request( "http://127.0.0.1/set_comparison_strict"
-    , "GET"
+mock_hackney_request( "GET"
+    , "http://127.0.0.1/set_comparison_strict"
     , _
     , _
     , _Timeout
-    , _Options
 ) ->
   {ok, {{200, []}, [
     {"content-type", "application/json"}
@@ -126,12 +125,11 @@ mock_lhttpc_request( "http://127.0.0.1/set_comparison_strict"
 "/utf8>>}};
 %% Mock response for set_comparison test:
 %% (match a finite set of values):
-mock_lhttpc_request( "http://127.0.0.1/set_comparison_unlimited"
-    , "GET"
+mock_hackney_request( "GET"
+    , "http://127.0.0.1/set_comparison_unlimited"
     , _
     , _
     , _Timeout
-    , _Options
 ) ->
     {ok, {{200, []}, [
         {"content-type", "application/json"}
@@ -141,12 +139,11 @@ mock_lhttpc_request( "http://127.0.0.1/set_comparison_unlimited"
 "/utf8>>}};
 %% Mock response for set_comparison_unexpected test:
 %% (match any set of value, except the unexpected)
-mock_lhttpc_request( "http://127.0.0.1/set_comparison_unexpected"
-    , "GET"
+mock_hackney_request( "GET"
+    , "http://127.0.0.1/set_comparison_unexpected"
     , _
     , _
     , _Timeout
-    , _Options
 ) ->
     {ok, {{200, []}, [
         {"content-type", "application/json"}


### PR DESCRIPTION
Allow Katt to function when embedded into code bases that use other http clients than hackney (such as ones that are still stuck with lhttpc :P)