### PR TITLE
hackney -> httpc

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,12 +32,6 @@
       , {tag, "2.8.0"}
       }
     }
-  , { hackney
-    , ".*"
-    , { git, "git://github.com/benoitc/hackney.git"
-      , {tag, "1.4.9"}
-      }
-    }
   , { neotoma
     , ".*"
     , { git, "git://github.com/seancribbs/neotoma.git"

--- a/src/katt.app.src
+++ b/src/katt.app.src
@@ -14,7 +14,6 @@
                                      , asn1
                                      , public_key
                                      , ssl
-                                     , hackney
                                      , tdiff
                                      ]}
                     ]}.

--- a/src/katt_cli.erl
+++ b/src/katt_cli.erl
@@ -105,7 +105,6 @@ katt_run(ScenarioFilename, Params) ->
   ok = ensure_started(idna),
   ok = ensure_started(mimerl),
   ok = ensure_started(certifi),
-  ok = ensure_started(hackney),
   ok = ensure_started(tdiff),
   ok = ensure_started(katt),
   katt:run( ScenarioFilename


### PR DESCRIPTION
see #34 

although I would guess one major decision in using lhttpc in the early katt beginnings was the stupidity of this type httpc definition:
`method() = head | get | put | post | trace | options | delete`

FWIW: Just an exercise. I don't intend to have this merged.