### PR TITLE
use hackney 1.15.2 already has the honor_cipher_order fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,8 +36,8 @@
 { optional_deps
 , [ { hackney
     , ".*"
-    , { git, "git://github.com/andreineculau/hackney.git"
-      , {tag, "1.15.1-honor_cipher_order"}
+    , { git, "git://github.com/benoitc/hackney.git"
+      , {tag, "1.15.2"}
       }
     }
   , { jsx


### PR DESCRIPTION
it seems they already fixed the issue in the 1.15.2