### PR TITLE
remove warnings_as_errors to be able to use with otp23+ versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,6 @@
                       , warn_unused_import
                       , warn_unused_record
                       , warn_unused_vars
-                      , warnings_as_errors
                       ]}.
 {cover_enabled,       true}.
 {cover_print_enabled, true}.


### PR DESCRIPTION
katt can not be compiled with otp 23+ because of the usage of a depracated http_uri:parse function call
it can be replaced with uri_string:parse, but that is not available in otp versions older than 21.0
swith off the warnings_as_errors temporary option is a solution