### PR TITLE
Change pre to post compile hook due to changes in rebar3 behaviour

### DIFF
--- a/priv/compile-parser
+++ b/priv/compile-parser
@@ -4,10 +4,10 @@
 %% grammar file.
 
 main(_) ->
-    %% Katt is the main project
-    Neotoma1 = filename:dirname(escript:script_name()) ++ "/../deps/neotoma/ebin",
-    %% Katt is a dependency
-    Neotoma2 = filename:dirname(escript:script_name()) ++ "/../../neotoma/ebin",
-    code:add_pathz(filename:absname(Neotoma1)),
-    code:add_pathz(filename:absname(Neotoma2)),
+
+    DepsDir = os:getenv("REBAR_DEPS_DIR"),
+    
+    Neotoma =  DepsDir ++ "/neotoma/ebin",
+    
+    code:add_pathz(filename:absname(Neotoma)),
     neotoma:file("priv/katt_blueprint.peg", [{output, "src/"}]).

--- a/rebar.config
+++ b/rebar.config
@@ -61,7 +61,7 @@
       }
     }
   ]}.
-{pre_hooks, [{compile, "./priv/compile-parser"}]}.
+{post_hooks, [{compile, "./priv/compile-parser"}]}.
 {escript_name, "bin/katt"}.
 {escript_emu_args, "%%! -noinput\n"}.
 {escript_incl_apps, [ jsx


### PR DESCRIPTION
- Replaced relative paths to neotoma with REBAR_DEPS_DIR env variable
- Change the netoma parse call from _pre_ to _post_ compile hook. this changes was required due to changes to the way rebar3 handles compiler hooks.

more details here : https://github.com/erlang/rebar3/pull/2211
