### PR TITLE
Fail with {not_equal, {Key, Expected, Actual, TextDiff}} when expected empty list but got something else

### DIFF
--- a/src/katt_util.erl
+++ b/src/katt_util.erl
@@ -435,6 +435,25 @@ validate( ParentKey
 validate(ParentKey, E, A, ItemsMode, Callbacks) ->
   validate_simple(ParentKey, E, A, ItemsMode, Callbacks).
 
+%% Expected empty list, got empty list
+validate_proplist( _ParentKey
+                 , []
+                 , []
+                 , _ItemsMode
+                 , _Callbacks
+                 ) ->
+  {pass, []};
+
+%% Expected empty list, got something else
+validate_proplist( ParentKey
+                 , []
+                 , AItems
+                 , _ItemsMode
+                 , Callbacks
+                 ) ->
+  TextDiffFun = proplists:get_value(text_diff, Callbacks),
+  {not_equal, {ParentKey, [], AItems, TextDiffFun([], AItems)}};
+
 validate_proplist( ParentKey
                  , EItems0
                  , AItems


### PR DESCRIPTION
Currently when an empty list `[]` is defined in apib:
```json
  {
    "hello": []
  }
```
a list containing any element will pass the test:
```json
  {
    "hello": ["this", "will", "pass"]
  }
```
This PR makes it fail with:
```erlang
{not_equal,
  {"/body/hello",[],
    [{"0","this"},{"1","will"},{"2","pass"}],
    [{text_diff,
      [{ins,
        [{"0","this"},
          {"1","will"},
          {"2","pass"}]}]}]}}
```
instead of 
```erlang
{pass,[]}
```