### PR TITLE
allow for content-type to be set via 'x-katt-content-type' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,14 @@ bin/katt --json base_url=http://httpbin.org my_name=Joe your_name=Mike -- doc/ex
 
 A request can also be configured via HTTP request headers:
 
+* `x-katt-content-type` would set a request content-type, without sending a `content-type` HTTP header
 * `x-katt-description` would take precedence over the transaction's description
 * `x-katt-request-timeout` would take precedence over the `request_timeout` param
 * `x-katt-request-sleep` would delay the request for a specific amount of milliseconds
 * `x-katt-transform` would call the `tranform` callback with its value as `id`
 
 A response can also be configured via HTTP response headers:
+* `x-katt-content-type` would set a response (expected and actual) content-type, without expecting/receiving a `content-type` HTTP header
 * `x-katt-transform` would call the `tranform` callback with its value as `id`
 
 ### If you would like to convert a HAR file to an APIB file

--- a/src/katt_callbacks.erl
+++ b/src/katt_callbacks.erl
@@ -165,14 +165,12 @@ parse(Hdrs, Body, Params, Callbacks) ->
              , params()
              , callbacks()
              ) -> response().
-request(R = #katt_request{}, Params, Callbacks) ->
-  ParseFun = proplists:get_value(parse, Callbacks),
+request(R = #katt_request{}, Params, _Callbacks) ->
   case http_request(R, Params) of
     {ok, {{Code, _}, Hdrs, Body}} ->
       #katt_response{ status = Code
                     , headers = Hdrs
                     , body = Body
-                    , parsed_body = ParseFun(Hdrs, Body, Params, Callbacks)
                     };
     Error = {error, _} ->
       Error


### PR DESCRIPTION
Fixes #66 

Altering the content-type of the actual response should already be possible in the Erlang API (see https://github.com/for-GET/katt/blob/f2a30915aa2b4aa6a3e54fd16b3a88f512e74fc2/src/katt.erl#L337-L351) with
* a `transform` (enforce JSON for a specific transaction)
* an `ext` callback (enforce JSON for all transactions, regardless of the headers)
* a `request` callback that wraps the transaction

None of that is available to the CLI API. And even with the Erlang API, it is not straightforward.

My suggestion is to introduce support for `x-katt-content-type` request/response headers.

Example:

```
# Response with "content-type: text/plain" that we want to treat as application/json

The actual response body is literally '{"foo": "bar"}' i.e. without the extra whitespace as below.
But since we treat it as JSON, the whitespace is ignored.

GET https://run.mocky.io/v3/8ac0bd80-840f-402d-a9ad-421707194110
< 200
< x-katt-content-type: application/json
{  "foo": "bar"  }

```