### PR TITLE
remove logic from http_status definition in bp peg file

### DIFF
--- a/priv/katt_blueprint.peg
+++ b/priv/katt_blueprint.peg
@@ -237,7 +237,7 @@ response_header <-
   `;
 
 http_status <-
-  [1-5] [0-9] [0-9]
+  [0-9]+
   `
     {Int, _Rest} = string:to_integer(unicode:characters_to_list(concatenate_chars(Node))),
     Int


### PR DESCRIPTION
  *http_status definition in katt_blueprint.peg file
   defines that valid http_status must have exactly
   3 digits, of which first digit must be in range
   1...5, second and third digit can be any digit.
   When http_status is set to invalid value in apib
   file (according to the definition in bp peg
   file), parser will fail to parse that value as
   http_status. This failure will be propagated
   and parsing of that specific transaction will
   also fail. By definition if this will be first
   transaction in apib file (and there must be at
   least one transaction defined), parsing will
   fail. If this is not the first transaction,
   parser will try to parse it as the next element
   defined in bp peg file (footer). So when
   invalid value of http_status is set in
   transaction (which is not the first one defined
   in apib file), that transaction (and all after
   that one will be parsed as footer).
   As a result runing katt will test only first
   few transactions from apib file (all defined
   before the one with invalid http_status) and
   all other transaction will be just ignored.
   Testcase will pass even tough not all
   transactions from apib file were tested.
  *change in this commit defines http_status
   as any non-neg integer and leaves to katt
   to match received http_status with expected
   from apib file.